### PR TITLE
Add code to find "first_repeating", "second_repeating", "third_odd" & "nth_element" in a List 

### DIFF
--- a/Assignments/assignment10/Cargo.toml
+++ b/Assignments/assignment10/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "assignment10"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+log = "0.4.14"
+env_logger = "0.8.3"

--- a/Assignments/assignment10/src/datastore.rs
+++ b/Assignments/assignment10/src/datastore.rs
@@ -1,0 +1,4 @@
+pub enum List {
+    Cons(i32, Box<List>),
+    Nil,
+}

--- a/Assignments/assignment10/src/lib.rs
+++ b/Assignments/assignment10/src/lib.rs
@@ -1,0 +1,10 @@
+mod test ;
+mod datastore;
+
+pub mod tasks {
+    pub mod first_repeated;
+    pub mod second_repeated;
+    pub mod nth_element;
+    pub mod third_odd;
+
+}

--- a/Assignments/assignment10/src/tasks/first_repeated.rs
+++ b/Assignments/assignment10/src/tasks/first_repeated.rs
@@ -1,0 +1,28 @@
+use log::*;
+use crate::datastore::List;
+use crate::datastore::List::{Nil, Cons};
+
+/// first_repeat function search the first repeated element
+///
+/// #Arguments
+///
+/// list- A iterable of enum object which contains the list of numbers.
+///
+/// random is an i32 variable containing the previous Cons in Cons tuple of List enum.
+///
+/// #Return
+///
+///  Return the i32 number contains the third odd number
+pub fn first_repeat(iterable:List, random: i32) ->i32 {
+    info!("This is the code for first repeated number");
+    match iterable {
+        Nil => -1,
+
+        Cons(initial, _iterable) if initial == random => initial,
+
+        Cons(initial, iterable) => first_repeat(*iterable, initial),
+    }
+}
+
+
+

--- a/Assignments/assignment10/src/tasks/nth_element.rs
+++ b/Assignments/assignment10/src/tasks/nth_element.rs
@@ -1,0 +1,24 @@
+use crate::datastore::List;
+use crate::datastore::List::{Nil, Cons};
+
+/// nth function finds the nth element.
+///
+/// #Arguments
+///
+/// iterable is an enum object.
+/// 
+/// counter used to iterate and change in every iteration
+///
+/// position stores the value of position
+///
+/// #Return
+///
+///  Return the i32 number contains the third odd number
+pub fn nth(position: i32, iterator:List, counter:i32) -> i32 {
+    match iterator {
+        Nil => -1,
+        Cons(current, _re) if counter == position => current,
+        Cons(_er, iterator) => nth(position, *iterator, counter + 1),
+    }
+    
+}

--- a/Assignments/assignment10/src/tasks/second_repeated.rs
+++ b/Assignments/assignment10/src/tasks/second_repeated.rs
@@ -1,0 +1,30 @@
+use crate::datastore::List;
+use crate::datastore::List::{Nil, Cons};
+/// second function finds the second repeated.
+///
+/// #Arguments
+///
+/// iterable is an enum object which contains the list of numbers.
+///
+/// repeat is used to stores count to find the second number
+///
+///previous An i32 variable containing the previous Cons in Cons tuple of List enum.
+///
+/// #Return
+///
+/// Return the i32 number contains the third odd number
+
+pub fn second(previous:i32, iterable:List, repeat: i32) ->i32 {
+    match iterable {
+        Nil => -1,
+        Cons(initial, _) if initial == previous && repeat == 1 => initial,
+        Cons(initial, iterable) if initial == previous => {
+            second(initial, *iterable, repeat + 1)
+        }
+        Cons(initial, iterable) => second(initial, *iterable, repeat),
+    }
+   
+}
+
+
+  

--- a/Assignments/assignment10/src/tasks/third_odd.rs
+++ b/Assignments/assignment10/src/tasks/third_odd.rs
@@ -1,0 +1,24 @@
+use crate::datastore::List;
+use crate::datastore::List::{Nil, Cons};
+/// find_odd function finds the third odd number.
+///
+/// #Arguments
+///
+/// iterable is an enum object which contains the list of numbers.
+///
+/// iterator used to find the odd number.
+///
+/// #Return
+///
+/// Return the i32 number contains the third odd number
+
+pub fn find_odd(iterable:List,iterator:i32) ->i32 {
+    match iterable {
+        Nil => -1,
+        Cons(initial, _iterable) if iterator == 1 && &initial & 1 == 1 => initial,
+
+        Cons(initial, iterable) if &initial & 1 == 1 => find_odd(*iterable, iterator - 1),
+
+        Cons(_initial, iterable) => find_odd(*iterable, iterator),
+    }
+}

--- a/Assignments/assignment10/src/test.rs
+++ b/Assignments/assignment10/src/test.rs
@@ -1,0 +1,170 @@
+mod tests {
+   pub use crate::tasks::nth_element::nth;
+    pub use crate::tasks::first_repeated::first_repeat;
+    pub use crate::tasks::second_repeated::second;
+    pub use crate::tasks::third_odd::find_odd;
+    pub use crate::datastore::List::{Nil, Cons};
+
+    #[test]
+    fn nth_search() {
+        env_logger::builder().is_test(true).try_init();
+        let test_list = Cons(
+            21,
+            Box::new(Cons(
+                22,
+                Box::new(Cons(
+                    33,
+                    Box::new(Cons(
+                        34,
+                        Box::new(Cons(5, Box::new(Cons(6, Box::new(Nil))))),
+                    )),
+                )),
+            )),
+        );
+        assert_eq!(nth(4, test_list,1), 34);
+        log::info!("This is nth element element result");
+
+    }
+
+    #[test]
+    fn nth_search_new() {
+         env_logger::builder().is_test(true).try_init();
+       let test_list = Cons(
+            1,
+            Box::new(Cons(
+                2,
+                Box::new(Cons(
+                    3,
+                    Box::new(Cons(
+                        4,
+                        Box::new(Cons(5, Box::new(Cons(6, Box::new(Nil))))),
+                    )),
+                )),
+            )),
+        );
+        assert_eq!(nth(3, test_list,1), 3);
+        log::info!("This is nth element element result");
+
+    }
+
+    #[test]
+    fn first_repeated() {
+        env_logger::builder().is_test(true).try_init();
+        let list_val = Cons(
+            1,
+            Box::new(Cons(
+                21,
+                Box::new(Cons(
+                    21,
+                    Box::new(Cons(
+                        43,
+                        Box::new(Cons(5, Box::new(Cons(5, Box::new(Nil))))),
+                    )),
+                )),
+            )),
+        );
+        assert_eq!(first_repeat(list_val,-1 ),21 );
+        log::info!("This is first repeating element result")
+
+
+    }
+
+    #[test]
+    fn first_repeated_nrw() {
+         env_logger::builder().is_test(true).try_init();
+         let list_val = Cons(
+            1,
+            Box::new(Cons(
+                21,
+                Box::new(Cons(
+                    12,
+                    Box::new(Cons(
+                        43,
+                        Box::new(Cons(5, Box::new(Cons(7, Box::new(Nil))))),
+                    )),
+                )),
+            )),
+        );
+        assert_eq!(first_repeat(list_val,-1),-1);
+        log::info!("This is first repeating element result");
+    }
+    #[test]
+    fn second_repeat_() {
+         env_logger::builder().is_test(true).try_init();
+        let box_array = Cons(
+            1,
+            Box::new(Cons(
+                21,
+                Box::new(Cons(
+                    21,
+                    Box::new(Cons(
+                        4,
+                        Box::new(Cons(7, Box::new(Cons(9, Box::new(Nil))))),
+                    )),
+                )),
+            )),
+        );
+        assert_eq!(second(21, box_array, 2),-1);
+        log::info!("This is second repeating element result");
+    }
+    #[test]
+    fn second_repeat_new() {
+         env_logger::builder().is_test(true).try_init();
+        let box_array = Cons(
+            1,
+            Box::new(Cons(
+                21,
+                Box::new(Cons(
+                    32,
+                    Box::new(Cons(
+                        4,
+                        Box::new(Cons(7, Box::new(Cons(9, Box::new(Nil))))),
+                    )),
+                )),
+            )),
+        );
+        assert_eq!(second(21, box_array, 2),-1);
+        log::info!("This is second repeating element result");
+    }
+
+    #[test]
+    fn third_odd() {
+        env_logger::builder().is_test(true).try_init();
+        let test_data = Cons(
+            1,
+            Box::new(Cons(
+                21,
+                Box::new(Cons(
+                    35,
+                    Box::new(Cons(
+                        4,
+                        Box::new(Cons(5, Box::new(Cons(6, Box::new(Nil))))),
+                    )),
+                )),
+            )),
+        );
+        assert_eq!(find_odd(test_data,3), 35);
+        log::info!("This is the third odd element result");
+    }
+    #[test]
+    fn third_odd_new() {
+        env_logger::builder().is_test(true).try_init();
+        let test_data = Cons(
+            21,
+            Box::new(Cons(
+                24,
+                Box::new(Cons(
+                    38,
+                    Box::new(Cons(
+                        45,
+                        Box::new(Cons(96, Box::new(Cons(6, Box::new(Nil))))),
+                    )),
+                )),
+            )),
+        );
+        assert_eq!(find_odd(test_data,3), -1);
+        log::info!("This is the third odd element result");
+    }
+}
+
+


### PR DESCRIPTION
What does this change do?
Added code in Rust to find "first_repeating", "second_repeating", "third_odd" & "nth_element" in a List using Smart Pointers.

Any additional information for the reviewer to start
NA

How should this be manually tested?
We need window OS in which Rust is installed. then execute this rust program

Are there any changes pending?
No

Does any team have to be notified of changes in this feature?
Yes

Definition of Done:
- [x] Is there >90% unit test code coverage?
- [x] Does this PR add new dependencies? If so, please list out the same.
       log = "0.4.14" env_logger = "0.8.3"
- [ ]  Will this feature require a new piece of infrastructure to be implemented?
- [x] Is there appropriate logging included?
- [x] Does the project compile ok?
- [x] Have Clippy violations been fixed?
- [x] Have Code is properly formatted?